### PR TITLE
netdb: Implement getnetent and getnetent_r

### DIFF
--- a/src/netdb/gethostent.c
+++ b/src/netdb/gethostent.c
@@ -1,0 +1,122 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define _GNU_SOURCE
+
+#include "lwb_netdb.h"
+#include "lwb_netdb_private.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static FILE *__file = NULL;
+
+static struct hostent *__gethostent(FILE *f, struct hostent *ent, char **line, size_t *size,
+                                    struct hostent **res, int *errnoptr)
+{
+        for (;;) {
+                ssize_t l = 0;
+                char *saveptr = NULL;
+                char *free_pos = NULL;
+                size_t aliases_max = 0;
+
+                if ((l = getline(line, size, f)) < 0) {
+                        *errnoptr = NO_RECOVERY;
+                        ent = NULL;
+                        break;
+                }
+                if (l == 0)
+                        continue;
+                if (*size <= (size_t)l + 1 + ENT_ADDRESS_SIZE) {
+                        *errnoptr = NO_RECOVERY;
+                        ent = NULL;
+                        break;
+                }
+                free_pos = *line + l + 1;
+                aliases_max = ALIASES_MAX(*size, (size_t)l, ENT_ADDRESS_SIZE);
+                ent->h_name = 0;
+                ent->h_aliases = 0;
+                __parse_comment(*line);
+                ent->h_addr_list = (char **)free_pos;
+                if (__parse_address_list(*line,
+                                         ent->h_addr_list,
+                                         &ent->h_addrtype,
+                                         &ent->h_length,
+                                         &saveptr,
+                                         &free_pos) != 1)
+                        continue;
+                if (__parse_name(NULL, &ent->h_name, &saveptr) != 1)
+                        break;
+                ent->h_aliases = (char **)free_pos;
+                __parse_aliases(ent->h_aliases, &saveptr, aliases_max);
+                break;
+        }
+        if (res)
+                *res = ent;
+        return ent;
+}
+
+void __wrap_sethostent(int stayopen __attribute__((unused)))
+{
+        if (__file != NULL)
+                fclose(__file);
+        __file = NULL;
+}
+
+void __wrap_endhostent(void)
+{
+        __wrap_sethostent(0);
+}
+
+static inline FILE *__open_hosts_file(void)
+{
+        if (__file == NULL)
+                __file = fopen("/etc/hosts", "r");
+        return __file;
+}
+
+int __wrap_gethostent_r(struct hostent *ret, char *buf, size_t buflen, struct hostent **res,
+                        int *h_errnop)
+{
+        if (__open_hosts_file() == NULL)
+                return 1;
+        if (__gethostent(__file, ret, &buf, &buflen, res, h_errnop) == NULL)
+                return 1;
+        return 0;
+}
+
+struct hostent *__wrap_gethostent(void)
+{
+        static char *__buf = NULL;
+        static size_t __size = 0;
+        static struct hostent __ent;
+        struct hostent *res = &__ent;
+        if (__buf == NULL) {
+                __buf = calloc(1, MAX_BUFFER_SIZE);
+                __size = MAX_BUFFER_SIZE;
+        }
+        if (__wrap_gethostent_r(&__ent, __buf, __size, &res, &errno) == 1)
+                return NULL;
+        return res;
+}

--- a/src/netdb/getnetent.c
+++ b/src/netdb/getnetent.c
@@ -1,0 +1,115 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define _GNU_SOURCE
+
+#include "lwb_netdb.h"
+#include "lwb_netdb_private.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static FILE *__file = NULL;
+
+static struct netent *__getnetent(FILE *f, struct netent *ent, char **line, size_t *size,
+                                  struct netent **res, int *errnoptr)
+{
+        for (;;) {
+                ssize_t l = 0;
+                char *saveptr = NULL;
+                char *free_pos = NULL;
+
+                if ((l = getline(line, size, f)) < 0) {
+                        *errnoptr = NO_RECOVERY;
+                        ent = NULL;
+                        break;
+                }
+                if (l == 0)
+                        continue;
+                if (*size <= (size_t)l + 1) {
+                        *errnoptr = NO_RECOVERY;
+                        ent = NULL;
+                        break;
+                }
+                free_pos = *line + l + 1;
+                ent->n_name = 0;
+                ent->n_aliases = 0;
+                __parse_comment(*line);
+                if (__parse_name(*line, &ent->n_name, &saveptr) != 1)
+                        continue;
+                if (__parse_address(NULL, &ent->n_net, &saveptr) != 1)
+                        continue;
+                ent->n_net = htonl(ent->n_net);
+                ent->n_aliases = (char **)free_pos;
+                __parse_aliases(ent->n_aliases, &saveptr, ALIASES_MAX(*size, (size_t)l, 0));
+                break;
+        }
+        if (res)
+                *res = ent;
+        return ent;
+}
+
+void __wrap_setnetent(int stayopen __attribute__((unused)))
+{
+        if (__file != NULL)
+                fclose(__file);
+        __file = NULL;
+}
+
+void __wrap_endnetent(void)
+{
+        __wrap_setnetent(0);
+}
+
+static inline FILE *__open_hosts_file(void)
+{
+        if (__file == NULL)
+                __file = fopen("/etc/networks", "r");
+        return __file;
+}
+
+int __wrap_getnetent_r(struct netent *ret, char *buf, size_t buflen, struct netent **res,
+                       int *h_errnop)
+{
+        if (__open_hosts_file() == NULL)
+                return 1;
+        if (__getnetent(__file, ret, &buf, &buflen, res, h_errnop) == NULL)
+                return 1;
+        return 0;
+}
+
+struct netent *__wrap_getnetent(void)
+{
+        static char *__buf = NULL;
+        static size_t __size = 0;
+        static struct netent __ent;
+        struct netent *res = &__ent;
+        if (__buf == NULL) {
+                __buf = calloc(1, MAX_BUFFER_SIZE);
+                __size = MAX_BUFFER_SIZE;
+        }
+        if (__wrap_getnetent_r(&__ent, __buf, __size, &res, &errno) == 1)
+                return NULL;
+        return res;
+}

--- a/src/netdb/lwb_netdb.c
+++ b/src/netdb/lwb_netdb.c
@@ -25,42 +25,23 @@
 #define _GNU_SOURCE
 
 #include "lwb_netdb.h"
+#include "lwb_netdb_private.h"
 #include <arpa/inet.h>
-#include <errno.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 
-#define MAX_LINE_SIZE 1024
-#define MAX_ALIASES 32
-#define ENT_ADDRESS_LIST_SIZE (2 * sizeof(char *))
-#define ENT_ADDRESS_ENTRY_SIZE sizeof(struct in6_addr)
-#define ENT_ADDRESS_SIZE (ENT_ADDRESS_LIST_SIZE + ENT_ADDRESS_ENTRY_SIZE)
-#define MAX_BUFFER_SIZE (MAX_LINE_SIZE + MAX_ALIASES * sizeof(char *) + ENT_ADDRESS_SIZE)
-static FILE *__file = NULL;
 static const char *delims = " \t\n";
-
-void __wrap_sethostent(int stayopen __attribute__((unused)))
-{
-        if (__file != NULL)
-                fclose(__file);
-        __file = NULL;
-}
-
-void __wrap_endhostent(void)
-{
-        __wrap_sethostent(0);
-}
 
 int __str_to_addr(const char *str, void *addr, int *family, int *addr_length)
 {
         if (inet_aton(str, (struct in_addr *)addr) == 1) {
-                *family = AF_INET;
-                *addr_length = sizeof(struct in_addr);
+                if (family != NULL)
+                        *family = AF_INET;
+                if (addr_length != NULL)
+                        *addr_length = sizeof(struct in_addr);
                 return 1;
         }
-        if (inet_pton(AF_INET6, str, (struct in6_addr *)addr) == 1) {
+        if (family != NULL && inet_pton(AF_INET6, str, (struct in6_addr *)addr) == 1) {
                 *family = AF_INET6;
                 *addr_length = sizeof(struct in6_addr);
                 return 1;
@@ -68,95 +49,62 @@ int __str_to_addr(const char *str, void *addr, int *family, int *addr_length)
         return 0;
 }
 
-static struct hostent *__gethostent(FILE *f, struct hostent *ent, char **line, size_t *size,
-                                    struct hostent **res, int *errnoptr)
+int __parse_address_list(char *line, char **addr_list, int *family, int *add_length, char **saveptr,
+                         char **free_pos)
 {
-        for (;;) {
-                ssize_t l = 0;
-                char *item = NULL;
-                char *saveptr = NULL;
-                char *free_pos = NULL;
-                size_t aliases_max = 0;
-                size_t aliases_cnt = 0;
+        char *item = strtok_r(line, delims, saveptr);
+        if (item == NULL)
+                return 0;
+        *free_pos += ENT_ADDRESS_LIST_SIZE;
+        addr_list[0] = *free_pos;
+        addr_list[1] = NULL;
+        *free_pos += ENT_ADDRESS_ENTRY_SIZE;
+        if (__str_to_addr(item, addr_list[0], family, add_length) != 1)
+                return 0;
+        return 1;
+}
 
-                if ((l = getline(line, size, f)) < 0) {
-                        *errnoptr = NO_RECOVERY;
-                        ent = NULL;
-                        break;
-                }
-                if (l == 0)
-                        continue;
-                if (*size <= (size_t)l + 1 + ENT_ADDRESS_SIZE) {
-                        *errnoptr = NO_RECOVERY;
-                        ent = NULL;
-                        break;
-                }
-                free_pos = *line + l + 1;
-                aliases_max = (*size - (size_t)l - 1 - ENT_ADDRESS_SIZE) / sizeof(char *);
-                ent->h_name = 0;
-                ent->h_aliases = 0;
-                if ((item = strchr(*line, '#'))) {
-                        *item++ = '\n';
-                        *item = 0;
-                }
-                item = strtok_r(*line, delims, &saveptr);
-                if (item == NULL)
-                        continue;
-                ent->h_addr_list = (char **)free_pos;
-                free_pos += ENT_ADDRESS_LIST_SIZE;
-                ent->h_addr_list[0] = free_pos;
-                ent->h_addr_list[1] = NULL;
-                free_pos += ENT_ADDRESS_ENTRY_SIZE;
-                if (__str_to_addr(item, ent->h_addr_list[0], &ent->h_addrtype, &ent->h_length) != 1)
-                        continue;
-                item = strtok_r(NULL, delims, &saveptr);
-                if (item == NULL) {
-                        ent->h_name = "";
-                        break;
-                }
-                ent->h_name = item;
-                ent->h_aliases = (char **)free_pos;
-                item = strtok_r(NULL, delims, &saveptr);
-                for (aliases_cnt = 0; item != NULL && aliases_cnt < aliases_max; aliases_cnt++) {
-                        ent->h_aliases[aliases_cnt] = item;
-                        item = strtok_r(NULL, delims, &saveptr);
-                }
-                ent->h_aliases[aliases_cnt] = NULL;
-                break;
+int __parse_address(char *line, uint32_t *addr, char **saveptr)
+{
+        char *item = strtok_r(line, delims, saveptr);
+        if (item == NULL)
+                return 0;
+        if (__str_to_addr(item, addr, NULL, NULL) != 1)
+                return 0;
+        return 1;
+}
+
+int __parse_name(char *line, char **dst, char **saveptr)
+{
+        char *item = strtok_r(line, delims, saveptr);
+
+        if (item == NULL) {
+                *dst = "";
+                return 0;
         }
-        if (res)
-                *res = ent;
-        return ent;
+        *dst = item;
+        return 1;
 }
 
-static inline FILE *__open_hosts_file(void)
+void __parse_aliases(char **aliases, char **saveptr, size_t aliases_max)
 {
-        if (__file == NULL)
-                __file = fopen("/etc/hosts", "r");
-        return __file;
-}
+        char *item = NULL;
+        size_t aliases_cnt = 0;
 
-int __wrap_gethostent_r(struct hostent *ret, char *buf, size_t buflen, struct hostent **res,
-                        int *h_errnop)
-{
-        if (__open_hosts_file() == NULL)
-                return 1;
-        if (__gethostent(__file, ret, &buf, &buflen, res, h_errnop) == NULL)
-                return 1;
-        return 0;
-}
-
-struct hostent *__wrap_gethostent(void)
-{
-        static char *__buf = NULL;
-        static size_t __size = 0;
-        static struct hostent __ent;
-        struct hostent *res = &__ent;
-        if (__buf == NULL) {
-                __buf = calloc(1, MAX_BUFFER_SIZE);
-                __size = MAX_BUFFER_SIZE;
+        item = strtok_r(NULL, delims, saveptr);
+        for (aliases_cnt = 0; item != NULL && aliases_cnt < aliases_max; aliases_cnt++) {
+                aliases[aliases_cnt] = item;
+                item = strtok_r(NULL, delims, saveptr);
         }
-        if (__wrap_gethostent_r(&__ent, __buf, __size, &res, &errno) == 1)
-                return NULL;
-        return res;
+        aliases[aliases_cnt] = NULL;
+}
+
+void __parse_comment(char *line)
+{
+        char *c = NULL;
+
+        if ((c = strchr(line, '#'))) {
+                *c++ = '\n';
+                *c = 0;
+        }
 }

--- a/src/netdb/lwb_netdb_private.h
+++ b/src/netdb/lwb_netdb_private.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __LWB_NETDB_PRIVATE_H
+#define __LWB_NETDB_PRIVATE_H
+
+#define MAX_LINE_SIZE 1024
+#define MAX_ALIASES 32
+#define ENT_ADDRESS_LIST_SIZE (2 * sizeof(char *))
+#define ENT_ADDRESS_ENTRY_SIZE sizeof(struct in6_addr)
+#define ENT_ADDRESS_SIZE (ENT_ADDRESS_LIST_SIZE + ENT_ADDRESS_ENTRY_SIZE)
+#define MAX_BUFFER_SIZE (MAX_LINE_SIZE + MAX_ALIASES * sizeof(char *) + ENT_ADDRESS_SIZE)
+#define ALIASES_MAX(S, C, E) ((S - C - E - 1) / sizeof(char *))
+
+int __str_to_addr(const char *str, void *addr, int *family, int *addr_length);
+int __parse_address_list(char *line, char **addr_list, int *family, int *add_length, char **saveptr,
+                         char **free_pos);
+int __parse_address(char *line, uint32_t *addr, char **saveptr);
+int __parse_name(char *line, char **dst, char **saveptr);
+void __parse_aliases(char **aliases, char **saveptr, size_t aliases_max);
+void __parse_comment(char *line);
+
+#endif /* __LWB_NETDB_PRIVATE_H */

--- a/src/netdb/meson.build
+++ b/src/netdb/meson.build
@@ -1,7 +1,7 @@
 pkg = import('pkgconfig')
 
 libnetdb = static_library('wildebeest-netdb',
-    sources: ['lwb_netdb.c'],
+    sources: ['lwb_netdb.c', 'gethostent.c', 'getnetent.c'],
     install: true,
     include_directories: root_includedir,
 )
@@ -9,5 +9,5 @@ libnetdb = static_library('wildebeest-netdb',
 pkg.generate(libnetdb,
     name: 'libwildebeest-netdb',
     subdirs: 'libwildebeest',
-    libraries: '-Wl,--wrap=sethostent -Wl,--wrap=endhostent -Wl,--wrap=gethostent -Wl,--wrap=gethostent_r',
+    libraries: '-Wl,--wrap=sethostent -Wl,--wrap=endhostent -Wl,--wrap=gethostent -Wl,--wrap=gethostent_r -Wl,--wrap=setnetent -Wl,--wrap=endnetent -Wl,--wrap=getnetent -Wl,--wrap=getnetent_r',
 )


### PR DESCRIPTION
Refactor gethostent functions to more general parsing for entries.
Implement corresponiding getnetent functions.

This is alternative way to get same as on #3 so just merge either select that, or this one.