### PR TITLE
printf: Implement parse_printf_format

### DIFF
--- a/src/printf/lwb_printf.c
+++ b/src/printf/lwb_printf.c
@@ -28,12 +28,132 @@
 
 #include "printf.h"
 
-/**
- * Not yet implemented!
- */
+static inline void __assign_argtypes(int *__restrict __argtypes, size_t pos, size_t max, int value)
+{
+        if (pos < max)
+                __argtypes[pos] = value;
+}
+
 size_t __wrap_parse_printf_format(const char *__restrict __fmt, size_t __n,
                                   int *__restrict __argtypes)
 {
-#warning "parse_printf_format: NOT YET IMPLEMENTED"
-        return 0;
+        const char *p = NULL;
+        int type = 0;
+        int in_format = 0;
+        size_t res = 0;
+
+        if (!__fmt)
+                return 0;
+
+        for (p = __fmt; *p != 0; p++) {
+                if (in_format == 0 && *p == '%') {
+                        in_format = 1;
+                        type = 0;
+                } else if (in_format == 1 && *p == '%') {
+                        in_format = 0;
+                } else if (in_format) {
+                        switch (*p) {
+                        /* Conversion specifiers */
+                        case 'd':
+                        case 'i':
+                        case 'o':
+                        case 'u':
+                        case 'x':
+                        case 'X':
+                                /* Looks like integers can't have PA_FLAG_LONG_LONG */
+                                if ((type & PA_FLAG_LONG_LONG) != 0)
+                                        type ^= PA_FLAG_LONG_LONG;
+
+                                if (type == PA_CHAR)
+                                        __assign_argtypes(__argtypes, res++, __n, PA_CHAR);
+                                else
+                                        __assign_argtypes(__argtypes, res++, __n, type | PA_INT);
+                                in_format = 0;
+                                break;
+                        case 'f':
+                        case 'F':
+                        case 'e':
+                        case 'E':
+                        case 'g':
+                        case 'G':
+                        case 'a':
+                        case 'A':
+                                if ((type & PA_FLAG_LONG_LONG) != 0)
+                                        __assign_argtypes(__argtypes,
+                                                          res++,
+                                                          __n,
+                                                          PA_FLAG_LONG_LONG | PA_DOUBLE);
+                                else
+                                        __assign_argtypes(__argtypes, res++, __n, PA_DOUBLE);
+                                in_format = 0;
+                                break;
+                        case 'c':
+                                __assign_argtypes(__argtypes, res++, __n, PA_CHAR);
+                                in_format = 0;
+                                break;
+                        case 's':
+                                __assign_argtypes(__argtypes, res++, __n, PA_STRING);
+                                in_format = 0;
+                                break;
+                        case 'p':
+                                __assign_argtypes(__argtypes, res++, __n, PA_POINTER);
+                                in_format = 0;
+                                break;
+                        case 'n':
+                                __assign_argtypes(__argtypes, res++, __n, PA_FLAG_PTR);
+                                in_format = 0;
+                                break;
+
+                        /* Length modifiers */
+                        case 'L':
+                                type |= PA_FLAG_LONG_LONG;
+                                break;
+                        case 'j':
+                        case 'z':
+                        case 't':
+                                type |= PA_FLAG_LONG;
+                                break;
+                        case 'l':
+                                if ((type & PA_FLAG_LONG) != 0 || (type & PA_FLAG_LONG_LONG) != 0)
+                                        type |= PA_FLAG_LONG_LONG;
+                                else
+                                        type |= PA_FLAG_LONG;
+                                break;
+                        case 'h':
+                                if ((type & PA_FLAG_SHORT) != 0)
+                                        type = PA_CHAR;
+                                else
+                                        type |= PA_FLAG_SHORT;
+                                break;
+
+                        /* Numbers and flags */
+                        case '0':
+                        case '1':
+                        case '2':
+                        case '3':
+                        case '4':
+                        case '5':
+                        case '6':
+                        case '7':
+                        case '8':
+                        case '9':
+                        case '.':
+                        case '#':
+                        case '+':
+                        case '-':
+                        case '\'':
+                                break;
+                        case '*':
+                                __assign_argtypes(__argtypes, res++, __n, PA_INT);
+                                break;
+
+                        default:
+                                in_format = 0;
+                                break;
+                        }
+                } else
+                        in_format = 0;
+        }
+
+        return res > 0 ? res - 1 : res;
 }


### PR DESCRIPTION
Does not handle properly all invalid format strings, should however work on most of the cases.

Clean room implementation, checked output of existing implementation and adjusted this one accordingly.