### PR TITLE
From musl

### DIFF
--- a/src/ftw/lwb_ftw.c
+++ b/src/ftw/lwb_ftw.c
@@ -20,6 +20,29 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ *
+ * This is mostly copied from musl, original license:
+ *
+ * Copyright © 2005-2020 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #ifndef _XOPEN_SOURCE
@@ -27,6 +50,14 @@
 #endif
 
 #include "lwb_ftw.h"
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 int __wrap_ftw(const char *dir, int (*funcc)(const char *, const struct stat *, int),
                int descriptors)
@@ -35,9 +66,149 @@ int __wrap_ftw(const char *dir, int (*funcc)(const char *, const struct stat *, 
         return -1;
 }
 
+struct history {
+        struct history *chain;
+        dev_t dev;
+        ino_t ino;
+        int level;
+        int base;
+};
+
+static int do_nftw(char *path, int (*fn)(const char *, const struct stat *, int, struct FTW *),
+                   int fd_limit, int flags, struct history *h)
+{
+        size_t l = strlen(path), j = l && path[l - 1] == '/' ? l - 1 : l;
+        struct stat st;
+        struct history new;
+        int type;
+        int r;
+        int dfd;
+        int err;
+        int recurse;
+        struct FTW lev;
+
+        if ((flags & FTW_PHYS) ? lstat(path, &st) : stat(path, &st) < 0) {
+                if (!(flags & FTW_PHYS) && errno == ENOENT && !lstat(path, &st))
+                        type = FTW_SLN;
+                else if (errno != EACCES)
+                        return -1;
+                else
+                        type = FTW_NS;
+        } else if (S_ISDIR(st.st_mode)) {
+                if (flags & FTW_DEPTH)
+                        type = FTW_DP;
+                else
+                        type = FTW_D;
+        } else if (S_ISLNK(st.st_mode)) {
+                if (flags & FTW_PHYS)
+                        type = FTW_SL;
+                else
+                        type = FTW_SLN;
+        } else {
+                type = FTW_F;
+        }
+
+        if ((flags & FTW_MOUNT) && h && st.st_dev != h->dev)
+                return 0;
+
+        new.chain = h;
+        new.dev = st.st_dev;
+        new.ino = st.st_ino;
+        new.level = h ? h->level + 1 : 0;
+        new.base = j + 1;
+
+        lev.level = new.level;
+        if (h) {
+                lev.base = h->base;
+        } else {
+                size_t k;
+                for (k = j; k && path[k] == '/'; k--)
+                        ;
+                for (; k && path[k - 1] != '/'; k--)
+                        ;
+                lev.base = k;
+        }
+
+        if (type == FTW_D || type == FTW_DP) {
+                dfd = open(path, O_RDONLY);
+                err = errno;
+                if (dfd < 0 && err == EACCES)
+                        type = FTW_DNR;
+                if (!fd_limit)
+                        close(dfd);
+        }
+
+        recurse = 1;
+        if (!(flags & FTW_DEPTH) && (r = fn(path, &st, type, &lev))) {
+                if ((flags & FTW_ACTIONRETVAL) && r == FTW_SKIP_SUBTREE)
+                        recurse = 0;
+                else
+                        return r;
+        }
+
+        for (; h; h = h->chain)
+                if (h->dev == st.st_dev && h->ino == st.st_ino)
+                        return 0;
+
+        if ((type == FTW_D || type == FTW_DP) && fd_limit) {
+                if (dfd < 0) {
+                        errno = err;
+                        return -1;
+                }
+                DIR *d = fdopendir(dfd);
+                if (d) {
+                        struct dirent *de;
+                        while ((de = readdir(d))) {
+                                if (de->d_name[0] == '.' &&
+                                    (!de->d_name[1] || (de->d_name[1] == '.' && !de->d_name[2])))
+                                        continue;
+                                if (strlen(de->d_name) >= PATH_MAX - l) {
+                                        errno = ENAMETOOLONG;
+                                        closedir(d);
+                                        return -1;
+                                }
+                                path[j] = '/';
+                                strcpy(path + j + 1, de->d_name);
+                                if (recurse && (r = do_nftw(path, fn, fd_limit - 1, flags, &new))) {
+                                        closedir(d);
+                                        if ((flags & FTW_ACTIONRETVAL) && r == FTW_SKIP_SIBLINGS)
+                                                return 0;
+                                        return r;
+                                }
+                        }
+                        closedir(d);
+                } else {
+                        close(dfd);
+                        return -1;
+                }
+        }
+
+        path[l] = 0;
+        if ((flags & FTW_DEPTH) && (r = fn(path, &st, type, &lev)))
+                return r;
+
+        return 0;
+}
+
 int __wrap_nftw(const char *dir, int (*func)(const char *, const struct stat *, int, struct FTW *),
                 int descriptors, int flag)
 {
-#warning "nftw not yet implemented"
-        return -1;
+        int r, cs;
+        size_t l;
+        char pathbuf[PATH_MAX + 1];
+
+        if (descriptors <= 0)
+                return 0;
+
+        l = strlen(dir);
+        if (l > PATH_MAX) {
+                errno = ENAMETOOLONG;
+                return -1;
+        }
+        memcpy(pathbuf, dir, l + 1);
+
+        pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &cs);
+        r = do_nftw(pathbuf, func, descriptors, flag, NULL);
+        pthread_setcancelstate(cs, 0);
+        return r;
 }

--- a/src/ftw/meson.build
+++ b/src/ftw/meson.build
@@ -10,5 +10,5 @@ pkg.generate(libftw,
     name: 'libwildebeest-ftw',
     subdirs: 'libwildebeest',
     extra_cflags: '--include=lwb_ftw.h',
-    libraries: '-Wl,--wrap=ftw -Wl,--wrap=nftw',
+    libraries: '-Wl,--wrap=nftw',
 )

--- a/src/glob/lwb_glob.c
+++ b/src/glob/lwb_glob.c
@@ -20,20 +20,441 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
+ *
+ * This is mostly copied from musl, original license:
+ *
+ * Copyright © 2005-2020 Rich Felker, et al.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 #ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE
 #endif
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 
 #include "lwb_glob.h"
 
-int __wrap_glob(const char *pattern, int flags, int (*errfunc)(const char *, int), glob_t *pglob)
+#include <dirent.h>
+#include <errno.h>
+#include <fnmatch.h>
+#include <limits.h>
+#include <pwd.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+struct match {
+        struct match *next;
+        char name[];
+};
+
+static int append(struct match **tail, const char *name, size_t len, int mark)
 {
-#warning "glob not yet implemented"
+        struct match *new = malloc(sizeof(struct match) + len + 2);
+        if (!new)
+                return -1;
+        (*tail)->next = new;
+        new->next = NULL;
+        memcpy(new->name, name, len + 1);
+        if (mark && len && name[len - 1] != '/') {
+                new->name[len] = '/';
+                new->name[len + 1] = 0;
+        }
+        *tail = new;
+        return 0;
+}
+
+static int do_glob(char *buf, size_t pos, int type, char *pat, int flags,
+                   int (*errfunc)(const char *path, int err), struct match **tail)
+{
+        /* If GLOB_MARK is unused, we don't care about type. */
+        if (!type && !(flags & GLOB_MARK))
+                type = DT_REG;
+
+        /* Special-case the remaining pattern being all slashes, in
+         * which case we can use caller-passed type if it's a dir. */
+        if (*pat && type != DT_DIR)
+                type = 0;
+        while (pos + 1 < PATH_MAX && *pat == '/')
+                buf[pos++] = *pat++;
+
+        /* Consume maximal [escaped-]literal prefix of pattern, copying
+         * and un-escaping it to the running buffer as we go. */
+        ptrdiff_t i = 0, j = 0;
+        int in_bracket = 0, overflow = 0;
+        for (; pat[i] != '*' && pat[i] != '?' && (!in_bracket || pat[i] != ']'); i++) {
+                if (!pat[i]) {
+                        if (overflow)
+                                return 0;
+                        pat += i;
+                        pos += j;
+                        i = j = 0;
+                        break;
+                } else if (pat[i] == '[') {
+                        in_bracket = 1;
+                } else if (pat[i] == '\\' && !(flags & GLOB_NOESCAPE)) {
+                        /* Backslashes inside a bracket are (at least by
+                         * our interpretation) non-special, so if next
+                         * char is ']' we have a complete expression. */
+                        if (in_bracket && pat[i + 1] == ']')
+                                break;
+                        /* Unpaired final backslash never matches. */
+                        if (!pat[i + 1])
+                                return 0;
+                        i++;
+                }
+                if (pat[i] == '/') {
+                        if (overflow)
+                                return 0;
+                        in_bracket = 0;
+                        pat += i + 1;
+                        i = -1;
+                        pos += j + 1;
+                        j = -1;
+                }
+                /* Only store a character if it fits in the buffer, but if
+                 * a potential bracket expression is open, the overflow
+                 * must be remembered and handled later only if the bracket
+                 * is unterminated (and thereby a literal), so as not to
+                 * disallow long bracket expressions with short matches. */
+                if (pos + (j + 1) < PATH_MAX) {
+                        buf[pos + j++] = pat[i];
+                } else if (in_bracket) {
+                        overflow = 1;
+                } else {
+                        return 0;
+                }
+                /* If we consume any new components, the caller-passed type
+                 * or dummy type from above is no longer valid. */
+                type = 0;
+        }
+        buf[pos] = 0;
+        if (!*pat) {
+                /* If we consumed any components above, or if GLOB_MARK is
+                 * requested and we don't yet know if the match is a dir,
+                 * we must confirm the file exists and/or determine its type.
+                 *
+                 * If marking dirs, symlink type is inconclusive; we need the
+                 * type for the symlink target, and therefore must try stat
+                 * first unless type is known not to be a symlink. Otherwise,
+                 * or if that fails, use lstat for determining existence to
+                 * avoid false negatives in the case of broken symlinks. */
+                struct stat st;
+                if ((flags & GLOB_MARK) && (!type || type == DT_LNK) && !stat(buf, &st)) {
+                        if (S_ISDIR(st.st_mode))
+                                type = DT_DIR;
+                        else
+                                type = DT_REG;
+                }
+                if (!type && lstat(buf, &st)) {
+                        if (errno != ENOENT && (errfunc(buf, errno) || (flags & GLOB_ERR)))
+                                return GLOB_ABORTED;
+                        return 0;
+                }
+                if (append(tail, buf, pos, (flags & GLOB_MARK) && type == DT_DIR))
+                        return GLOB_NOSPACE;
+                return 0;
+        }
+        char *p2 = strchr(pat, '/'), saved_sep = '/';
+        /* Check if the '/' was escaped and, if so, remove the escape char
+         * so that it will not be unpaired when passed to fnmatch. */
+        if (p2 && !(flags & GLOB_NOESCAPE)) {
+                char *p;
+                for (p = p2; p > pat && p[-1] == '\\'; p--)
+                        ;
+                if ((p2 - p) % 2) {
+                        p2--;
+                        saved_sep = '\\';
+                }
+        }
+        DIR *dir = opendir(pos ? buf : ".");
+        if (!dir) {
+                if (errfunc(buf, errno) || (flags & GLOB_ERR))
+                        return GLOB_ABORTED;
+                return 0;
+        }
+        int old_errno = errno;
+        struct dirent *de;
+        while (errno = 0, de = readdir(dir)) {
+                /* Quickly skip non-directories when there's pattern left. */
+                if (p2 && de->d_type && de->d_type != DT_DIR && de->d_type != DT_LNK)
+                        continue;
+
+                size_t l = strlen(de->d_name);
+                if (l >= PATH_MAX - pos)
+                        continue;
+
+                if (p2)
+                        *p2 = 0;
+
+                int fnm_flags = ((flags & GLOB_NOESCAPE) ? FNM_NOESCAPE : 0) |
+                                ((!(flags & GLOB_PERIOD)) ? FNM_PERIOD : 0);
+
+                if (fnmatch(pat, de->d_name, fnm_flags))
+                        continue;
+
+                /* With GLOB_PERIOD, don't allow matching . or .. unless
+                 * fnmatch would match them with FNM_PERIOD rules in effect. */
+                if (p2 && (flags & GLOB_PERIOD) && de->d_name[0] == '.' &&
+                    (!de->d_name[1] || de->d_name[1] == '.' && !de->d_name[2]) &&
+                    fnmatch(pat, de->d_name, fnm_flags | FNM_PERIOD))
+                        continue;
+
+                memcpy(buf + pos, de->d_name, l + 1);
+                if (p2)
+                        *p2 = saved_sep;
+                int r = do_glob(buf, pos + l, de->d_type, p2 ? p2 : "", flags, errfunc, tail);
+                if (r) {
+                        closedir(dir);
+                        return r;
+                }
+        }
+        int readerr = errno;
+        if (p2)
+                *p2 = saved_sep;
+        closedir(dir);
+        if (readerr && (errfunc(buf, errno) || (flags & GLOB_ERR)))
+                return GLOB_ABORTED;
+        errno = old_errno;
+        return 0;
+}
+
+static int ignore_err(const char *path, int err)
+{
+        return 0;
+}
+
+static void freelist(struct match *head)
+{
+        struct match *match, *next;
+        for (match = head->next; match; match = next) {
+                next = match->next;
+                free(match);
+        }
+}
+
+static int sort(const void *a, const void *b)
+{
+        return strcmp(*(const char **)a, *(const char **)b);
+}
+
+static int expand_tilde(char **pat, char *buf, size_t *pos)
+{
+        char *p = *pat + 1;
+        size_t i = 0;
+
+        char delim, *name_end = strchrnul(p, '/');
+        if ((delim = *name_end))
+                *name_end++ = 0;
+        *pat = name_end;
+
+        char *home = *p ? NULL : getenv("HOME");
+        if (!home) {
+                struct passwd pw, *res;
+                switch (*p ? getpwnam_r(p, &pw, buf, PATH_MAX, &res)
+                           : getpwuid_r(getuid(), &pw, buf, PATH_MAX, &res)) {
+                case ENOMEM:
+                        return GLOB_NOSPACE;
+                case 0:
+                        if (!res)
+                        default:
+                                return GLOB_NOMATCH;
+                }
+                home = pw.pw_dir;
+        }
+        while (i < PATH_MAX - 2 && *home)
+                buf[i++] = *home++;
+        if (*home)
+                return GLOB_NOMATCH;
+        if ((buf[i] = delim))
+                buf[++i] = 0;
+        *pos = i;
+        return 0;
+}
+
+static const char *__brace_next(const char *p)
+{
+        int level = 0;
+
+        for (; p && *p; ++p) {
+                if (*p == '{')
+                        level++;
+                else if (*p == '}') {
+                        if (!level)
+                                break;
+                        --level;
+                } else if (*p == ',' && !level)
+                        break;
+        }
+        return p && *p ? p : NULL;
+}
+
+static int __parse_brace(const char *s, char *buf, int bufpos, int maxlen, int pos, int flags,
+                         char *res, int (*errfunc)(const char *path, int err), struct match **tail)
+{
+        const char *iter = s;
+        if (!buf)
+                buf = calloc(1, maxlen);
+
+        for (; iter && *iter; iter++) {
+                if (*iter == '{') {
+                        const char *item = __brace_next(iter + 1);
+                        const char *end = item;
+                        while (end && *end != '}')
+                                end = __brace_next(end + 1);
+
+                        if (item && end) {
+                                const char *p = iter + 1;
+                                while (item) {
+                                        char *newstring = calloc(1, maxlen);
+                                        memcpy(newstring, p, item - p);
+                                        memcpy(newstring + strlen(newstring),
+                                               end + 1,
+                                               strlen(s) - (end + 1 - s));
+
+                                        __parse_brace(newstring,
+                                                      buf,
+                                                      bufpos,
+                                                      maxlen,
+                                                      pos,
+                                                      flags,
+                                                      res,
+                                                      errfunc,
+                                                      tail);
+                                        memset(buf + bufpos, 0, maxlen - bufpos);
+                                        if (*item == '}' || !*item)
+                                                break;
+                                        p = item + 1;
+                                        item = __brace_next(p);
+                                }
+                        }
+                        break;
+                } else
+                        buf[bufpos++] = *iter;
+        }
+        if (!*iter)
+                return do_glob(res, pos, 0, buf, flags, errfunc, tail);
+        return 0;
+}
+
+int __wrap_glob(const char *restrict pat, int flags, int (*errfunc)(const char *path, int err),
+                glob_t *restrict g)
+{
+        struct match head = { .next = NULL }, *tail = &head;
+        size_t cnt, i;
+        size_t offs = (flags & GLOB_DOOFFS) ? g->gl_offs : 0;
+        int error = 0;
+        char buf[PATH_MAX];
+
+        if (!errfunc)
+                errfunc = ignore_err;
+
+        if (!(flags & GLOB_APPEND)) {
+                g->gl_offs = offs;
+                g->gl_pathc = 0;
+                g->gl_pathv = NULL;
+        }
+
+        if (*pat) {
+                char *p = strdup(pat);
+                if (!p)
+                        return GLOB_NOSPACE;
+                buf[0] = 0;
+                size_t pos = 0;
+                char *s = p;
+                if ((flags & (GLOB_TILDE | GLOB_TILDE_CHECK)) && *p == '~')
+                        error = expand_tilde(&s, buf, &pos);
+                if (!error) {
+                        if (flags & GLOB_BRACE)
+                                error = __parse_brace(s,
+                                                      NULL,
+                                                      0,
+                                                      strlen(s),
+                                                      pos,
+                                                      flags,
+                                                      buf,
+                                                      errfunc,
+                                                      &tail);
+                        else
+                                error = do_glob(buf, pos, 0, s, flags, errfunc, &tail);
+                }
+                free(p);
+        }
+
+        if (error == GLOB_NOSPACE) {
+                freelist(&head);
+                return error;
+        }
+
+        for (cnt = 0, tail = head.next; tail; tail = tail->next, cnt++)
+                ;
+        if (!cnt) {
+                if (flags & GLOB_NOCHECK) {
+                        tail = &head;
+                        if (append(&tail, pat, strlen(pat), 0))
+                                return GLOB_NOSPACE;
+                        cnt++;
+                } else
+                        return GLOB_NOMATCH;
+        }
+
+        if (flags & GLOB_APPEND) {
+                char **pathv =
+                    realloc(g->gl_pathv, (offs + g->gl_pathc + cnt + 1) * sizeof(char *));
+                if (!pathv) {
+                        freelist(&head);
+                        return GLOB_NOSPACE;
+                }
+                g->gl_pathv = pathv;
+                offs += g->gl_pathc;
+        } else {
+                g->gl_pathv = malloc((offs + cnt + 1) * sizeof(char *));
+                if (!g->gl_pathv) {
+                        freelist(&head);
+                        return GLOB_NOSPACE;
+                }
+                for (i = 0; i < offs; i++)
+                        g->gl_pathv[i] = NULL;
+        }
+        for (i = 0, tail = head.next; i < cnt; tail = tail->next, i++)
+                g->gl_pathv[offs + i] = tail->name;
+        g->gl_pathv[offs + i] = NULL;
+        g->gl_pathc += cnt;
+
+        if (!(flags & GLOB_NOSORT))
+                qsort(g->gl_pathv + offs, cnt, sizeof(char *), sort);
+
+        return error;
 }
 
 void __wrap_globfree(glob_t *g)
 {
-#warning "globfree not yet implemented!"
+        size_t i;
+        for (i = 0; i < g->gl_pathc; i++)
+                free(g->gl_pathv[g->gl_offs + i] - offsetof(struct match, name));
+        free(g->gl_pathv);
+        g->gl_pathc = 0;
+        g->gl_pathv = NULL;
 }

--- a/src/include/lwb_stdlib.h
+++ b/src/include/lwb_stdlib.h
@@ -1,0 +1,46 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* We might be used with old compiler settings. */
+#ifndef _LWB_STDLIB_H
+#define _LWB_STDLIB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lwb_common.h"
+
+#include <locale.h>
+#include <stddef.h>
+
+long long strtoll_l(const char *restrict s, char **restrict p, int base, locale_t l);
+unsigned long long strtoull_l(const char *restrict s, char **restrict p, int base,
+                                     locale_t l);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _LWB_STDLIB_H */

--- a/src/include/meson.build
+++ b/src/include/meson.build
@@ -7,6 +7,7 @@ headers = [
     'lwb_glob.h',
     'lwb_ftw.h',
     'lwb_pwd.h',
+    'lwb_stdlib.h',
 ]
 
 install_headers(headers, subdir: meson.project_name())

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,6 +14,7 @@ subdir('glob')
 subdir('ftw')
 subdir('netdb')
 subdir('pwd')
+subdir('stdlib')
 
 # Generate a global pkgconfig for enabling all features
 pkg.generate(name: 'libwildebeest',
@@ -28,5 +29,6 @@ pkg.generate(name: 'libwildebeest',
         'libwildebeest-ftw',
         'libwildebeest-netdb',
         'libwildebeest-pwd',
+        'libwildebeest-stdlib',
     ],
 )

--- a/src/stdlib/lwb_stdlib.c
+++ b/src/stdlib/lwb_stdlib.c
@@ -1,0 +1,41 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _XOPEN_SOURCE
+#define _XOPEN_SOURCE
+#endif
+
+#include "lwb_stdlib.h"
+#include <stdlib.h>
+
+long long __wrap_strtoll_l(const char *restrict s, char **restrict p, int base, locale_t l)
+{
+        return strtoll(s, p, base);
+}
+
+unsigned long long __wrap_strtoull_l(const char *restrict s, char **restrict p, int base,
+                                     locale_t l)
+{
+        return strtoull(s, p, base);
+}

--- a/src/stdlib/meson.build
+++ b/src/stdlib/meson.build
@@ -1,0 +1,14 @@
+pkg = import('pkgconfig')
+
+libstdlib = static_library('wildebeest-stdlib',
+    sources: ['lwb_stdlib.c'],
+    install: true,
+    include_directories: root_includedir,
+)
+
+pkg.generate(libstdlib,
+    name: 'libwildebeest-stdlib',
+    subdirs: 'libwildebeest',
+    extra_cflags: '--include=lwb_stdlib.h',
+    libraries: '-Wl,--wrap=strtoll_l -Wl,--wrap=strtoull_l',
+)


### PR DESCRIPTION
Most of this code is copied from musl.

- Copy glob from musl and add support for GLOB_BRACE
- Copy nftw, and add support for FTW_ACTIONRETVAL, FTW_SKIP_SUBTREE and FTW_SKIP_SIBLINGS 
- Simple wrappers for strtoll_l and strtoull_l ignoring locale