### PR TITLE
unistd: Implement faccessat

### DIFF
--- a/src/include/lwb_unistd.h
+++ b/src/include/lwb_unistd.h
@@ -1,0 +1,41 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* We might be used with old compiler settings. */
+#ifndef _LWB_UNISTD_H
+#define _LWB_UNISTD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "lwb_common.h"
+
+int faccessat(int fd, const char *filename, int amode, int flag);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _LWB_UNISTD_H */

--- a/src/include/meson.build
+++ b/src/include/meson.build
@@ -8,6 +8,7 @@ headers = [
     'lwb_ftw.h',
     'lwb_pwd.h',
     'lwb_stdlib.h',
+    'lwb_unistd.h',
 ]
 
 install_headers(headers, subdir: meson.project_name())

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ subdir('ftw')
 subdir('netdb')
 subdir('pwd')
 subdir('stdlib')
+subdir('unistd')
 
 # Generate a global pkgconfig for enabling all features
 pkg.generate(name: 'libwildebeest',
@@ -30,5 +31,6 @@ pkg.generate(name: 'libwildebeest',
         'libwildebeest-netdb',
         'libwildebeest-pwd',
         'libwildebeest-stdlib',
+        'libwildebeest-unistd',
     ],
 )

--- a/src/unistd/lwb_unistd.c
+++ b/src/unistd/lwb_unistd.c
@@ -1,0 +1,75 @@
+/*
+ * This file is part of libwildebeest
+ *
+ * Copyright © 2020 Serpent OS Developers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "lwb_unistd.h"
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define HAS_MODE(M, U, G, O, UID, GID)                                                             \
+        ((UID == M.st_uid && ((M.st_mode) & U)) || (GID == M.st_gid && ((M.st_mode) & G)) ||       \
+         ((M.st_mode) & O))
+
+int __wrap_faccessat(int fd, const char *filename, int amode, int flag)
+{
+        if (flag) {
+                struct stat statbuf;
+                int res;
+                uid_t uid;
+                uid_t gid;
+                if (flag & AT_EACCESS) {
+                        uid = geteuid();
+                        gid = getegid();
+                } else {
+                        uid = getuid();
+                        gid = getgid();
+                }
+                /* Filter out AT_EACCESS here and just pass AT_SYMLINK_NOFOLLOW if specified */
+                res = fstatat(AT_FDCWD, filename, &statbuf, flag & AT_SYMLINK_NOFOLLOW);
+                if (res)
+                        return -1;
+                /* Special case, root has always access */
+                if (getuid() == 0)
+                        return 0;
+                switch (amode) {
+                case F_OK:
+                        return 0;
+                case X_OK:
+                        return HAS_MODE(statbuf, S_IXUSR, S_IXGRP, S_IXOTH, uid, gid) ? 0 : -1;
+                case W_OK:
+                        return HAS_MODE(statbuf, S_IWUSR, S_IWGRP, S_IWOTH, uid, gid) ? 0 : -1;
+                case R_OK:
+                        return HAS_MODE(statbuf, S_IRUSR, S_IRGRP, S_IROTH, uid, gid) ? 0 : -1;
+                }
+                return -1;
+        }
+
+        return (int)syscall(SYS_faccessat, fd, filename, amode);
+}

--- a/src/unistd/meson.build
+++ b/src/unistd/meson.build
@@ -1,0 +1,14 @@
+pkg = import('pkgconfig')
+
+libunistd = static_library('wildebeest-unistd',
+    sources: ['lwb_unistd.c'],
+    install: true,
+    include_directories: root_includedir,
+)
+
+pkg.generate(libunistd,
+    name: 'libwildebeest-unistd',
+    subdirs: 'libwildebeest',
+    extra_cflags: '--include=lwb_unistd.h',
+    libraries: '-Wl,--wrap=faccessat',
+)


### PR DESCRIPTION
Currently musl does not support AT_SYMLINK_NOFOLLOW for faccessat, thus reimplement it, and support properly all the specified flags.
